### PR TITLE
Enable integration test in CI

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -1,5 +1,12 @@
 name: cargo-deny
-on: [push, pull_request]
+on:
+    push:
+      paths-ignore:
+        - "**.md"
+    pull_request:
+      paths-ignore:
+        - "**.md"
+  
 jobs:
   cargo-deny:
     runs-on: ubuntu-20.04

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+    push:
+      paths-ignore:
+        - "**.md"
+    pull_request:
+      paths-ignore:
+        - "**.md"
 
 name: Format and Clippy
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,55 @@
+name: vTPM Integration Test on TDX server
+on:
+    push:
+      paths-ignore:
+        - "**.md"
+    pull_request:
+      paths-ignore:
+        - "**.md"
+
+env:
+  AS: nasm
+  RUST_TOOLCHAIN: nightly-2022-11-15
+  TOOLCHAIN_PROFILE: minimal
+
+jobs:
+  system_compile:
+    name: Run vTPM Integration Test
+    runs-on: [self-hosted, vtpm]
+
+    steps:
+      - name: Checkout sources - vTpm
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      
+      - name: Checkout sources - TDVF
+        run: |
+          rm -rf ../vtpm-tdvf
+          git clone --recursive --single-branch -b TDVF https://github.com/tianocore/edk2-staging ../vtpm-tdvf
+      
+      - name: Build vTPM td
+        run: |
+          rm -rf ../run-vtpm-td
+          mkdir ../run-vtpm-td
+          git submodule update --init --recursive
+          bash sh_script/pre-build.sh
+          bash sh_script/build.sh
+          cp target/x86_64-unknown-none/release/vtpmtd.bin ../run-vtpm-td
+      
+      - name: Build TDVF
+        run: |
+          pushd ../vtpm-tdvf
+          make -C BaseTools
+          source edksetup.sh
+          rm -rf ../run-user-td
+          mkdir ../run-user-td
+          build -p OvmfPkg/OvmfPkgX64.dsc -t GCC5 -a X64 -D TPM2_ENABLE=TRUE -D VTPM_ENABLE=TRUE -b RELEASE
+          cp Build/OvmfX64/RELEASE_GCC5/FV/OVMF.fd ../run-user-td/
+          popd
+
+      - name: Run test
+        run: |
+          pushd sh_script
+          python -m pytest -k "not stress"
+          popd

--- a/sh_script/launch_user_td.sh
+++ b/sh_script/launch_user_td.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+QEMU=/usr/local/bin/qemu-system-x86_64
+BIOS=
+KERNEL_IMAGE=
+GUEST_IMAGE=
+TEST_VTPM_IMAGE=
+FORWARD_PORT=10038
+TELNET_PORT=9032
+
+now=$(date +"%m%d_%H%M%S")
+LOGDIR=log_usertd
+LOGFILE=${LOGDIR}/usertd.${now}.log
+
+MEM=8G
+TARGET=shell
+USERTD_ID=aabbccdd-2012-2022-1234-123456789123
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -f <OVMF image file>      Firmware image file
+  -q <QEMU path>            QEMU path
+  -i <guest image file>     Guest image file, only for os 
+  -k <kernel file>          Kernel file, only for os
+  -u <user td id>           User TD ID - GUID
+  -v <test vTPM image>      Test vTPM image for shell
+  -t <boot to target>       Boot to [Shell/OS]
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "f:q:i:k:u:v:t:h" option; do
+        case "${option}" in
+            f) BIOS=$OPTARG;;
+            q) QEMU=$OPTARG;;
+            i) GUEST_IMAGE=$OPTARG;;
+            k) KERNEL_IMAGE=$OPTARG;;
+            u) USERTD_ID=$OPTARG;;
+            v) TEST_VTPM_IMAGE=$OPTARG;;
+            t) TARGET=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+    
+    if [[ ! -f ${BIOS} ]]; then
+        usage
+        echo "OVMF image file ${BIOS} not exist, Please specify via option \"-f\""
+        exit 1
+    fi
+
+    if [[ ! -f ${QEMU} ]]; then
+        usage
+        echo "QEMU ${QEMU} is not exist, Please specify via option \"-q\""
+        exit 1
+    fi
+
+    case $TARGET in
+        "shell")
+                if [[ ! -f ${TEST_VTPM_IMAGE} ]]; then
+                    usage
+                    echo "Test vTPM image ${TEST_VTPM_IMAGE} is not exist, Please specify via option \"-v\""
+                    exit 1
+                fi
+                MEM=1G
+                QEMU_CMD="$QEMU \
+                        -accel kvm \
+                        -name process=user-td-ci,debug-threads=on \
+                        -smp 1 \
+                        -m ${MEM} \
+                        -object tdx-guest,id=tdx,debug=on,vtpm-type=client,vtpm-userid=${USERTD_ID},vtpm-path=unix:/tmp/vtpm-server-${USERTD_ID}.sock \
+                        -object memory-backend-memfd-private,id=usertd-ram2-${USERTD_ID},size=${MEM} \
+                        -bios ${BIOS} \
+                        -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=usertd-ram2-${USERTD_ID} \
+                        -no-hpet \
+                        -cpu host,host-phys-bits,-kvm-steal-time,-arch-lbr  \
+                        -hda ${TEST_VTPM_IMAGE} \
+                        -serial stdio -nodefaults | tee -a ${LOGFILE}
+                        "
+                ;;
+        "os") 
+                if [[ ! -f ${GUEST_IMAGE} ]]; then
+                    usage
+                    echo "Guest image file ${GUEST_IMG} not exist. Please specify via option \"-i\""
+                    exit 1
+                fi
+
+                if [[ ! -f ${KERNEL_IMAGE} ]]; then
+                    usage
+                    echo "Kernel image file ${KERNEL_IMAGE} not exist. Please specify via option \"-k\""
+                    exit 1
+                fi
+                QEMU_CMD="$QEMU \
+                        -accel kvm \
+                        -no-reboot \
+                        -name process=user-td-ci,debug-threads=on \
+                        -cpu host,host-phys-bits,-kvm-steal-time,-arch-lbr \
+                        -smp 1 \
+                        -m ${MEM} \
+                        -object tdx-guest,id=tdx,debug=on,vtpm-type=client,vtpm-userid=${USERTD_ID},vtpm-path=unix:/tmp/vtpm-server-${USERTD_ID}.sock \
+                        -object memory-backend-memfd-private,id=usertd-ram2-${USERTD_ID},size=${MEM} \
+                        -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=usertd-ram2-${USERTD_ID} \
+                        -bios ${BIOS} \
+                        -nographic \
+                        -vga none \
+                        -chardev stdio,id=mux,mux=on,signal=off \
+                        -device virtio-serial,romfile= \
+                        -device virtconsole,chardev=mux \
+                        -serial chardev:mux \
+                        -monitor chardev:mux \
+                        -drive file=${GUEST_IMAGE},if=virtio,format=qcow2 \
+                        -device virtio-net-pci,netdev=mynet0 \
+                        -netdev user,id=mynet0,hostfwd=tcp::${FORWARD_PORT}-:22 \
+                        -kernel ${KERNEL_IMAGE} \
+                        -append \"root=/dev/vda1 ro console=hvc0\" \
+                        -monitor pty \
+                        -monitor telnet:127.0.0.1:${TELNET_PORT},server,nowait \
+                        -no-hpet \
+                        -nodefaults | tee -a ${LOGFILE}"
+                ;;
+        *) 
+                echo "Invalid ${TARGET}, must be [shell|os]"
+                exit 1
+                ;;
+    esac
+}
+
+create_log_dir() {
+    if [[ ! -d ${LOGDIR} ]]; then
+        echo "Create log folder: ${LOGDIR}"
+        mkdir ${LOGDIR}
+    fi
+}
+
+launch_user_td() {
+    create_log_dir
+    # echo ${QEMU_CMD}
+    eval $QEMU_CMD
+}
+
+process_args "$@"
+launch_user_td

--- a/sh_script/launch_vtpm_td.sh
+++ b/sh_script/launch_vtpm_td.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+QEMU=/usr/local/bin/qemu-system-x86_64
+BIOS=
+USERTD_ID=aabbccdd-2012-2022-1234-123456789123
+MEM=256M
+
+now=$(date +"%m%d_%H%M%S")
+LOGDIR=log_vtpmtd
+LOGFILE=${LOGDIR}/vtpmtd.${now}.log
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -f <vTPM image file>      Firmware image file
+  -q <QEMU path>            QEMU path
+  -u <user td id>           User TD ID - GUID
+  -h                        Show this help
+EOM
+}
+
+process_args() {
+    while getopts "f:q:u:h" option; do
+        case "${option}" in
+            f) BIOS=$OPTARG;;
+            q) QEMU=$OPTARG;;
+            u) USERTD_ID=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    if [[ ! -f ${BIOS} ]]; then
+        usage
+        echo "vTPM image file ${BIOS} not exist, Please specify via option \"-f\""
+        exit 1
+    fi
+
+    if [[ ! -f ${QEMU} ]]; then
+        usage
+        echo "QEMU ${QEMU} is not exist, Please specify via option \"-q\""
+        exit 1
+    fi
+
+    QEMU_CMD="$QEMU \
+            -accel kvm \
+            -name debug-threads=on,process=vtpm-td-ci \
+            -cpu host,host-phys-bits,-kvm-steal-time,-arch-lbr \
+            -smp 1 -m ${MEM} \
+            -object tdx-guest,id=tdx,debug=on,vtpm-type=server,vtpm-userid=${USERTD_ID},vtpm-path=unix:/tmp/vtpm-server-${USERTD_ID}.sock \
+            -qmp unix:/tmp/qmp-sock-vtpm-${USERTD_ID},server,nowait \
+            -object memory-backend-memfd-private,id=vtpm-ram1-${USERTD_ID},size=${MEM} \
+            -machine q35,kernel_irqchip=split,confidential-guest-support=tdx,memory-backend=vtpm-ram1-${USERTD_ID} \
+            -bios ${BIOS} \
+            -nographic \
+            -vga none \
+            -no-hpet \
+            -nodefaults \
+            -chardev stdio,id=mux,mux=on,signal=off,logfile=${LOGFILE} \
+            -device virtio-serial,romfile= \
+            -device virtconsole,chardev=mux -serial chardev:mux -monitor chardev:mux \
+            -d int -no-reboot"  
+}
+
+create_log_dir() {
+    if [[ ! -d ${LOGDIR} ]]; then
+        echo "Create log folder: ${LOGDIR}"
+        mkdir ${LOGDIR}
+    fi
+}
+
+launch_vtpm_td() {
+    create_log_dir
+    echo ${QEMU_CMD}
+    eval $QEMU_CMD
+}
+
+process_args "$@"
+launch_vtpm_td

--- a/sh_script/pyproject.toml
+++ b/sh_script/pyproject.toml
@@ -1,0 +1,19 @@
+[vtpm.config]
+qemu="/usr/local/bin/qemu-system-x86_64"
+vtpm_td_script = "launch_vtpm_td.sh"
+user_td_script = "launch_user_td.sh"
+vtpm_td_bios_img = "../../run-vtpm-td/vtpmtd.bin"
+user_td_bios_img = "../../run-user-td/OVMF.fd"
+kernel_img = "/home/env/vtpm/vmlinuz-jammy"
+guest_img = "/home/env/vtpm/td-guest-ubuntu-22.04-test.qcow2"
+vtpm_test_img = "/home/env/vtpm/vtpm.img"
+vtpm_test_img_mount_path = "/media/vtpm"
+default_user_id = "aabbccdd-2012-2022-1234-123456789123"
+default_startup_cmds = [
+  "fs0:",
+]
+default_wait_tools_run_seconds = 20
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-v -r fEsp"

--- a/sh_script/test_vtpm.py
+++ b/sh_script/test_vtpm.py
@@ -1,0 +1,190 @@
+"""
+test_vtpm.py
+
+Readme:
+--------------
+A vtpm test framework to help startup vtpm user td and check dump logs.
+
+- Please edit vtpm.config variables in `pyproject.toml` before use.
+- Please note vtpmtool requires sudo permission without being prompted to input a password.
+- Please don't run with root user otherwise there will be a env var issue that causes the launch of qemu to fail.
+
+Example:
+--------------
+$ python3 -m venv .venv
+$ source .venv/bin/active
+$ (.venv) pip install pytest psutil
+$ (.venv) vim pyproject.toml
+$ (.venv) pytest
+
+"""
+
+import time
+
+from vtpmtool import VtpmTool, vtpm_context
+
+
+def test_tcs001_launch_tdvf_without_vtpm():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(["fs0:", "Tcg2DumpLog.efi > event.log"])
+        ctx.start_user_td()
+        ctx.terminate_user_td()
+        content = ctx.read_log(filename="event.log")
+    assert content and Utils.EVENT_ERR_FLAG in content
+
+
+def test_tcs002_1_vtpm_1_user_check_eventlog():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(["fs0:", "Tcg2DumpLog.efi > event.log"])
+        ctx.default_run_and_terminate()
+        content = ctx.read_log(filename="event.log")
+    assert content and Utils.EVENT_ERR_FLAG not in content
+
+
+def test_tcs003_1_vtpm_1_user_reset():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(
+            ["fs0:", "Tcg2DumpLog.efi > event0.log", "reset"]
+        )
+        ctx.start_vtpm_td()
+        ctx.execute_qmp()
+        ctx.start_user_td()  # user td will be terminated because `reset` is not supported
+        content_before = ctx.read_log(filename="event0.log", auto_delete=False)
+
+        ctx.generate_startup_into_vtpm_test_img(["fs0:", "Tcg2DumpLog.efi > event1.log", "reset"])
+        ctx.start_user_td()
+        ctx.terminate_all_tds()
+        content_after = ctx.read_log(filename="event1.log", auto_delete=False)
+
+    assert content_before and content_before == content_after
+
+
+def test_tcs004_1_vtpm_1_user_check_acpi_table():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(
+            ["fs0:", "acpidump.efi -n tdtk > acpidump.log"]
+        )
+        ctx.default_run_and_terminate()
+        content = ctx.read_log(filename="acpidump.log")
+    assert content and Utils.TDTK_FLAG in content
+
+
+def test_tcs005_1_vtpm_1_user_check_rtmr():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(["fs0:", "RtmrDump.efi > rtmrdump.log"])
+        ctx.default_run_and_terminate()
+        content = ctx.read_log(filename="rtmrdump.log")
+
+    rtmr0, rtmr1, rtmr2, rtmr3 = [
+        Utils.extract_rtmr_value(content, i) for i in range(4)
+    ]
+
+    # check RTMR0 and RTMR3 - should not be zero
+    assert rtmr0 and any(c != "0" for c in rtmr0)
+    assert rtmr3 and any(c != "0" for c in rtmr3)
+
+    # check RTMR1 and RTMR2 - are equal with fixed value
+    expected_value = "879606558AC3776B815615CE42F361976430D931D5DA09D77E0C5EC08CC76D00F5D6CF5EB704B9ED19FF7CCCF47C9083"
+    assert rtmr1 == rtmr2 and rtmr1 == expected_value
+
+
+def test_tcs006_2_vtpm_2_user(count_overwrite: int = None):
+    total = count_overwrite or 2
+    results = []
+    envs = []
+
+    # start N pairs of vtpm_td + user_td
+    for i in range(total):
+        env = VtpmTool(use_default_user_id=False) # generate different user id for each
+        env.generate_startup_into_vtpm_test_img(
+            [
+                "fs0:",
+                "Tcg2DumpLog.efi > event.log",
+                "RtmrDump.efi > rtmrdump.log",
+                "acpidump.efi -n tdtk > acpidump.log",
+            ],
+        )
+        env.start_vtpm_td()
+        env.execute_qmp()
+
+        # no need to wait user td boot except the last user td
+        if i < (total - 1):
+            env.wait_tools_run_seconds = 0
+        env.start_user_td()
+        envs.append(env)
+
+    # terminate these pairs and read td logs
+    for env in envs:
+        env.cleanup()
+        time.sleep(1)
+        event_log = env.read_log(filename="event.log")
+        rtmr_log = env.read_log(filename="rtmrdump.log")
+        rtmr_values = [Utils.extract_rtmr_value(rtmr_log, i) for i in range(4)]
+        acpi_log = env.read_log(filename="acpidump.log")
+        results.append((event_log, rtmr_values, acpi_log))
+
+    # check results
+    for i in range(total - 1):
+        current, next = results[i], results[i + 1]
+
+        # check event log - not error
+        event, next_event = current[0], next[0]
+        assert Utils.EVENT_ERR_FLAG not in event
+
+def test_tcs007_10_vtpm_10_user():
+    test_tcs006_2_vtpm_2_user(count_overwrite=10)
+
+
+def test_tcs008_1_vtpm_1_user_stress_reset_500_cycles(cycle_overwrite: int = None):
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(
+            ["fs0:", "Tcg2DumpLog.efi > event.log", "reset"]
+        )
+        ctx.start_vtpm_td()
+        ctx.execute_qmp()
+        ctx.start_user_td()
+
+        cycle = cycle_overwrite or 500
+        for i in range(cycle):
+            event_log = ctx.read_log(filename="event.log")
+            assert event_log and Utils.EVENT_ERR_FLAG not in event_log
+            ctx.start_user_td()
+
+        ctx.terminate_all_tds()
+
+
+def test_tcs009_1_vtpm_1_user_launch_guest_kernel():
+    with vtpm_context() as ctx:
+        ctx.wait_tools_run_seconds = 20
+        ctx.start_vtpm_td()
+        ctx.execute_qmp()
+        ctx.start_user_td(with_guest_kernel=True)
+        ctx.terminate_all_tds()
+        content = ctx.read_console()
+    assert content and Utils.KERNEL_VTPM_FLAG in content
+
+
+def test_tcs010_send_create_command_twice_with_qmp():
+    with vtpm_context() as ctx:
+        ctx.generate_startup_into_vtpm_test_img(["fs0:", "Tcg2DumpLog.efi > event.log"])
+        ctx.start_vtpm_td()
+        ctx.execute_qmp()
+        ctx.execute_qmp()
+        ctx.start_user_td()
+        event_log = ctx.read_log(filename="event.log")
+    assert event_log and Utils.EVENT_ERR_FLAG not in event_log
+
+
+class Utils:
+    EVENT_ERR_FLAG = "ERROR: Locate Tcg2Protocol - Not Found"
+    TDTK_FLAG = "TDTK checks passed!"
+    KERNEL_VTPM_FLAG = "tpm: TDX vTPM 2.0 device"
+
+    @staticmethod
+    def extract_rtmr_value(s: str, index: int) -> str:
+        try:
+            rtmr_start = s.index(f"RTMR{index}")
+        except ValueError:
+            return ""
+        rtmr_end = s.index("\n", rtmr_start)
+        return s[rtmr_start + 7 : rtmr_end]

--- a/sh_script/vtpmtool.py
+++ b/sh_script/vtpmtool.py
@@ -1,0 +1,373 @@
+import inspect
+import json
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import threading
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, List
+
+import psutil
+import tomli
+
+
+@contextmanager
+def vtpm_context():
+    """
+    Create a VtpmTool instance with default user id. Cleanup when out of scope.
+
+    In most cases that are not necessary to run multiple pairs of TDs at the same time, use this method with `with` statement.
+    """
+    tool = VtpmTool(use_default_user_id=True)
+    try:
+        yield tool
+    finally:
+        tool.cleanup()
+
+
+class VtpmTool:
+    log_dir_name = f"log_{int(time.time())}"
+    max_stdout_save_size = 4096
+    short_id_counter = 0
+
+    def __init__(self, use_default_user_id: bool = False):
+        self.use_default_user_id = use_default_user_id
+
+        # variables from the config file
+        self.qemu: str = None
+        self.vtpm_td_script: str = None
+        self.user_td_script: str = None
+        self.vtpm_td_bios_img: str = None
+        self.user_td_bios_img: str = None
+        self.kernel_img: str = None
+        self.guest_img: str = None
+        self.vtpm_test_img: str = None
+        self.vtpm_test_img_mount_path: str = None
+        self.default_user_id: str = None
+        self.default_startup_cmds: List[str] = None
+        self.default_wait_tools_run_seconds: int = None
+        cfg = self._parse_toml_config()
+        for k, v in cfg.items():
+            setattr(self, k, v)
+
+        # other variables to init
+        self._threads: Dict[str, threading.Thread] = {}
+        self._host_procs: Dict[str, subprocess.Popen] = {}
+        self._td_stdout_saved: Dict[str, dict] = {}
+        self._lock = threading.Lock() # to safely access `_td_stdout_saved`
+
+        self.startup_cmds = self.default_startup_cmds
+        self.wait_tools_run_seconds = self.default_wait_tools_run_seconds
+        self.user_id = self.default_user_id if use_default_user_id else self._new_guid()
+
+        # setup logger
+        self.logger = self._get_unique_logger()
+        self.logger.debug(f"Read config from file: {cfg}")
+
+    @property
+    def use_replica_img(self) -> bool:
+        # reserve the same logic with launch script: if pass default user id, qemu uses origial image
+        return not self.use_default_user_id
+
+    def default_run_and_terminate(self):
+        """
+        Launch vtpm td and user td then terminate all tds.
+
+        To simplify the test, use this method in case the test needs to start and stop one vtpm td and one user td simultaneously.
+        """
+        self.start_vtpm_td()
+        self.execute_qmp()
+        self.start_user_td()
+        self.cleanup()
+
+    def read_log(self, filename: str, auto_delete: bool = True) -> str:
+        """
+        Read log file in guest file system and return content in string.
+
+        This will mount the qemu image and unmount after reading.
+        """
+        self.mount_vtpm_test_img()
+        file = os.path.join(self.vtpm_test_img_mount_path, filename)
+        try:
+            # the encoding of `>` redirect ouput is UCS-2 (UTF-16), ref: https://uefi.org/sites/default/files/resources/UEFI_Shell_2_2.pdf 3.4.4.1
+            with open(file, "r", encoding="utf-16") as f:
+                text = f.read()
+            self.logger.debug(f"Read '{file}' ok: {len(text)}")
+            if auto_delete:
+                self._exec_shell_cmd(f"sudo rm -f {file}")
+            return text
+        except Exception as e:
+            self.logger.error(f"An error occurred when read '{filename}': {e}")
+        finally:
+            self.unmount_vtpm_test_img()
+        return ""
+
+    def read_console(self) -> str:
+        """
+        Read console print of a terminated user td and return content in string.
+        """
+        user_td_thread = self._threads.get("user_td")
+        if user_td_thread:
+            user_td_thread.join()
+        with self._lock:
+            user_td_out = self._td_stdout_saved.get("user_td")
+        return user_td_out["stdout"] if user_td_out else ""
+
+    def generate_startup_into_vtpm_test_img(self, startup_cmds: List[str] = None) -> bool:
+        """
+        Create `startup.nsh` with default commands in config, and add the script into qemu image.
+        Use this method when the user td is not running.
+
+        Pass `startup_cmds` argument to overwrite default commands.
+        """
+
+        if self.use_replica_img:
+            replica_img = self._copy_qemu_image()
+            self.vtpm_test_img = replica_img
+            self.logger.debug(f"Image name updated: {self.vtpm_test_img}")
+
+        self.mount_vtpm_test_img()
+        startup_nsh = "\n".join(startup_cmds or self.startup_cmds)
+        wrote = self._write_uefi_startup_script(startup_file_content=startup_nsh)
+        self.unmount_vtpm_test_img()
+        self.logger.debug(
+            f"Write startup.nsh into qemu image '{self.vtpm_test_img}': {len(wrote)}"
+        )
+        return len(wrote) != 0
+
+    def mount_vtpm_test_img(self):
+        """
+        Mount QEMU image to host mount point.
+        """
+        self._exec_shell_cmd(f"sudo mount {self.vtpm_test_img} {self.vtpm_test_img_mount_path}")
+
+    def unmount_vtpm_test_img(self):
+        """
+        Unmount QEMU image.
+        """
+        self._exec_shell_cmd(f"sudo umount {self.vtpm_test_img_mount_path}")
+
+    def start_vtpm_td(self):
+        """
+        Start vtpm td alone.
+        """
+        thread_vtpm = threading.Thread(
+            target=self._exec_shell_cmd,
+            args=(
+                f"bash {self.vtpm_td_script} -q {self.qemu} -f {self.vtpm_td_bios_img} -u {self.user_id}",
+                "vtpm_td",
+            ),
+        )
+        self.logger.debug(f"Starting vtpm td ({self.user_id})")
+        thread_vtpm.start()
+        self._threads["vtpm_td"] = thread_vtpm
+        time.sleep(5)
+
+    def start_user_td(self, with_guest_kernel: bool = False):
+        """
+        Start user td alone.
+        """
+        boot_to = "os" if with_guest_kernel else "shell"
+
+        thread_user = threading.Thread(
+            target=self._exec_shell_cmd,
+            args=(
+                f"bash {self.user_td_script} -q {self.qemu} -f {self.user_td_bios_img} -i {self.guest_img} -v {self.vtpm_test_img} -k {self.kernel_img} -u {self.user_id} -t {boot_to}",
+                "user_td",
+            ),
+        )
+        self.logger.debug(f"Starting user td ({self.user_id})")
+        thread_user.start()
+        self._threads["user_td"] = thread_user
+
+        # wait for tools run
+        time.sleep(self.wait_tools_run_seconds)
+
+    def execute_qmp(self):
+        """
+        Execute qmp commands alone.
+        """
+        QMP_SOCK = f"/tmp/qmp-sock-vtpm-{self.user_id}"
+        QMP_CMDS = [
+            {"execute": "qmp_capabilities"},
+            {
+                "execute": "tdx-vtpm-create-instance",
+                "arguments": {"user-id": self.user_id},
+            },
+        ]
+        self._send_qmp_cmds(QMP_SOCK, QMP_CMDS)
+
+    def terminate_vtpm_td(self):
+        """
+        Terminate the vtpm td qemu process with SIGTERM alone.
+        """
+        root_proc = self._host_procs.get("vtpm_td")
+        self._try_terminate_procs(root_proc)
+
+    def terminate_user_td(self):
+        """
+        Terminate the user td qemu process with SIGTERM alone.
+        """
+        root_proc = self._host_procs.get("user_td")
+        self._try_terminate_procs(root_proc)
+
+    def terminate_all_tds(self):
+        """
+        Terminate all td qemu processes with SIGTERM.
+        """
+        if len(self._host_procs) == 0:
+            return
+        self.terminate_user_td()
+        self.terminate_vtpm_td()
+        self._host_procs = {}
+
+    def cleanup(self):
+        """
+        Clear storage of threads and processes. And make sure all qemu procs have been terminated.
+        """
+        self.terminate_all_tds()
+        self._wait_td_threads()
+        self._threads = {}
+        self._host_procs = {}
+        self._td_stdout_saved = {}
+
+    def _parse_toml_config(self) -> dict:
+        with open("pyproject.toml", "rb") as f:
+            cfg = tomli.load(f)
+        return cfg["vtpm"]["config"]
+
+    def _get_unique_logger(self) -> logging.Logger:
+        fmt = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        lg = logging.getLogger(f"{__name__}_{self.user_id}")
+        lg.setLevel(logging.DEBUG)
+
+        log_path = Path(os.path.join(self.log_dir_name, self._inspect_pytest_tc_name()))
+        log_path.mkdir(parents=True, exist_ok=True)
+        log_name = f"{self.user_id}.log"
+        file_handler = logging.FileHandler(os.path.join(log_path, log_name), "w+")
+        file_handler.setLevel(logging.DEBUG)
+        file_handler.setFormatter(fmt)
+        lg.addHandler(file_handler)
+        return lg
+
+    def _try_terminate_procs(self, popen: subprocess.Popen):
+        if not popen:
+            return
+        try:
+            root = psutil.Process(popen.pid)
+            root_cmd = " ".join(root.cmdline())
+            childs = root.children(recursive=True)
+            self.logger.debug(
+                f"Terminate subprocess {list(map(lambda p: p.cmdline()[0], childs))} launched by '{root_cmd}'"
+            )
+        except psutil.NoSuchProcess:
+            self.logger.error("Failed to terminate subprocess: NoSuchProcess")
+            return
+        for child in childs:
+            child.terminate()
+        root.terminate()
+
+    def _wait_td_threads(self):
+        for _, thread in self._threads.items():
+            thread.join()
+        self._threads = {}
+
+    def _write_uefi_startup_script(self, startup_file_content: str) -> str:
+        file = os.path.join("/tmp", "tmp-usertd-startup")
+        try:
+            with open(file, "w+") as f:
+                f.write(startup_file_content)
+        except Exception as e:
+            self.logger.error(f"An error occurred when write 'tmp-usertd-startup': {e}")
+            return ""
+        _, stderr = self._exec_shell_cmd(
+            command=f"sudo cp {file} {os.path.join(self.vtpm_test_img_mount_path, 'startup.nsh')}"
+        )
+        if len(stderr) != 0:
+            self.logger.error(f"An error occurred when copy file: {stderr}")
+            return ""
+        return startup_file_content
+
+    def _exec_shell_cmd(self, command: str, tag: str = None) -> tuple:
+        proc = subprocess.Popen(
+            command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        if tag:
+            self._host_procs[tag] = proc
+        output, error = proc.communicate()
+        stdout, stderr = output.decode().strip(), error.decode().strip()
+
+        if tag in ["vtpm_td", "user_td"]:
+            with self._lock:
+                self._td_stdout_saved[tag] = {
+                    "stdout": stdout[: self.max_stdout_save_size],
+                    "stderr": stderr[: self.max_stdout_save_size],
+                }
+        log_msg = f"Execute `{command}`, stdout: {stdout or 'null'}, stderr: {stderr or 'null'}"
+        if stderr:
+            self.logger.warning(log_msg)
+        else:
+            self.logger.debug(log_msg)
+        return (stdout, stderr)
+
+    def _send_qmp_cmds(self, unix_sock: str, cmds: List[dict]):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.connect(unix_sock)
+        self.logger.debug(f"Socket connected: {unix_sock}")
+        # receive hello msg
+        r = sock.recv(1024)
+        r_str = r.decode("utf-8").replace("\n", "").replace("\r", "")
+        self.logger.debug(f"QMP recv: {r_str}")
+        # send commands
+        for command_json in cmds:
+            send_str = json.dumps(command_json)
+            send_str += "\n"
+            self.logger.debug(f"QMP send: {send_str.encode('utf-8')}")
+            sock.sendall(send_str.encode("utf-8"))
+            time.sleep(0.5)
+
+            r = sock.recv(1024)
+            r_str = r.decode("utf-8").replace("\n", "").replace("\r", "")
+            self.logger.debug(f"QMP recv: {r_str}")
+        sock.close()
+
+    def _inspect_pytest_tc_name(self):
+        func_list = list(map(lambda frame: frame.function, inspect.stack()))
+        # search test case name by pytest convention
+        tc_func_idx = func_list.index("pytest_pyfunc_call") - 1
+        if tc_func_idx > 0 and func_list[tc_func_idx].startswith("test_"):
+            return func_list[tc_func_idx]
+        else:
+            return ""
+
+    def _copy_qemu_image(self) -> str:
+        # check if vtpm_test_img is already a replica img
+        if self.vtpm_test_img.endswith(self.user_id):
+            return self.vtpm_test_img  # no need to copy
+
+        prototype_img = self.vtpm_test_img
+        replica_img = f"{os.path.basename(prototype_img)}.{self.user_id}"
+        if Path(replica_img).exists():
+            self.logger.debug(
+                f"Replica image won't be created because '{replica_img}' exists"
+            )
+            return replica_img
+        try:
+            dst = shutil.copy2(prototype_img, replica_img)
+            self.logger.debug(f"Replica image created: {dst}")
+        except Exception as e:
+            self.logger.error(
+                f"An error occurred when copy from {prototype_img} to {replica_img}"
+            )
+            return None
+        return replica_img
+
+    def _new_guid(self) -> str:
+        id = uuid.uuid4()
+        VtpmTool.short_id_counter += 1
+        return f"{VtpmTool.short_id_counter:03d}{str(id)[3:]}"


### PR DESCRIPTION
Initial integration test, added 10 test cases:
1. Launch user td without vtpm
2. Launch 1 vtpm + 1 user td, check event log
3. Launch 1 vtpm + 1 user td, reset
4. Launch 1 vtpm + 1 user td, check rtmr
5. Launch 1 vtpm + 1 user td, check acpi table
6. Launch 2 vtpm + 2 user td
7. Launch 10 vtpm + 10 user td
8. User td reset stress test
9. Launch guest kernel
10. Send create command twice with qmp to vtpm