### PR TITLE
Add deps/rust-tpm-20-ref/openssl-stubs/crypto/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ debug/
 
 # Executables
 *.out
+
+deps/rust-tpm-20-ref/openssl-stubs/crypto/


### PR DESCRIPTION
Fix #21