### PR TITLE
Update the critical to false for SUBJECT_ALT_NAME

### DIFF
--- a/src/crypto/src/ek_cert.rs
+++ b/src/crypto/src/ek_cert.rs
@@ -161,7 +161,7 @@ pub fn generate_ek_cert(
         .add_extension(Extension::new(KEY_USAGE, Some(true), Some(&ku))?)?
         .add_extension(Extension::new(
             SUBJECT_ALT_NAME,
-            Some(true),
+            Some(false),
             Some(&sub_alt_name),
         )?)?
         .sign(&mut sig_buf, signer)?


### PR DESCRIPTION
Refer to ek-credential spec Section 3.2.9 Subject Alternative Name,  this extension should be non-critical when subject is non-empty.