### PR TITLE
Fix ek-cert errors

### DIFF
--- a/src/crypto/src/ek_cert.rs
+++ b/src/crypto/src/ek_cert.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use alloc::vec;
-use der::asn1::{ObjectIdentifier, PrintableString, SetOfVec};
+use der::asn1::{BitString, ObjectIdentifier, OctetString, SetOfVec, Utf8String};
 use der::{Any, Encodable, Tag};
 use ring::digest;
 use ring::rand::SystemRandom;
@@ -11,9 +11,10 @@ use ring::signature::{EcdsaKeyPair, KeyPair};
 
 use crate::resolve::{
     AUTHORITY_KEY_IDENTIFIER, BASIC_CONSTRAINTS, EXTENDED_KEY_USAGE, EXTNID_VTPMTD_EVENT_LOG,
-    EXTNID_VTPMTD_QUOTE, ID_EC_SIG_OID, KEY_USAGE, VTPMTD_CA_EXTENDED_KEY_USAGE,
+    EXTNID_VTPMTD_QUOTE, ID_EC_SIG_OID, KEY_USAGE, TCG_EK_CERTIFICATE,
+    VTPMTD_CA_EXTENDED_KEY_USAGE,
 };
-use crate::x509::{self, DistinguishedName, Extension};
+use crate::x509::{self, AuthorityKeyIdentifier, DistinguishedName, Extension, SubjectAltName};
 use crate::{
     resolve::{ResolveError, ID_EC_PUBKEY_OID, SECP384R1_OID},
     x509::{AlgorithmIdentifier, X509Error},
@@ -59,36 +60,79 @@ pub fn generate_ca_cert(
         .to_vec()
         .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
 
-    let x509_certificate =
-        x509::CertificateBuilder::new(sig_alg, algorithm, ecdsa_keypair.public_key().as_ref())?
-            // 1970-01-01T00:00:00Z
-            .set_not_before(core::time::Duration::new(0, 0))?
-            // 9999-12-31T23:59:59Z
-            .set_not_after(core::time::Duration::new(253402300799, 0))?
-            .add_extension(Extension::new(
-                BASIC_CONSTRAINTS,
-                Some(true),
-                Some(basic_constrains.as_slice()),
-            )?)?
-            .add_extension(Extension::new(
-                EXTENDED_KEY_USAGE,
-                Some(false),
-                Some(eku.as_slice()),
-            )?)?
-            .add_extension(Extension::new(
-                EXTNID_VTPMTD_QUOTE,
-                Some(false),
-                Some(td_quote),
-            )?)?
-            .add_extension(Extension::new(
-                EXTNID_VTPMTD_EVENT_LOG,
-                Some(false),
-                Some(event_log),
-            )?)?
-            .sign(&mut sig_buf, signer)?
-            .build();
+    let x509_certificate = x509::CertificateBuilder::new(
+        sig_alg,
+        algorithm,
+        ecdsa_keypair.public_key().as_ref(),
+        true,
+    )?
+    // 1970-01-01T00:00:00Z
+    .set_not_before(core::time::Duration::new(0, 0))?
+    // 9999-12-31T23:59:59Z
+    .set_not_after(core::time::Duration::new(253402300799, 0))?
+    .add_extension(Extension::new(
+        BASIC_CONSTRAINTS,
+        Some(true),
+        Some(basic_constrains.as_slice()),
+    )?)?
+    .add_extension(Extension::new(
+        EXTENDED_KEY_USAGE,
+        Some(false),
+        Some(eku.as_slice()),
+    )?)?
+    .add_extension(Extension::new(
+        EXTNID_VTPMTD_QUOTE,
+        Some(false),
+        Some(td_quote),
+    )?)?
+    .add_extension(Extension::new(
+        EXTNID_VTPMTD_EVENT_LOG,
+        Some(false),
+        Some(event_log),
+    )?)?
+    .sign(&mut sig_buf, signer)?
+    .build();
 
     x509_certificate
+        .to_vec()
+        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))
+}
+
+fn gen_auth_key_identifier(ek_pub: &[u8]) -> Result<alloc::vec::Vec<u8>, ResolveError> {
+    // authority key identifier
+    let ek_pub_sha1 = digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, ek_pub);
+    let pub_sha1 = OctetString::new(ek_pub_sha1.as_ref())
+        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
+    let auth_key_identifier: AuthorityKeyIdentifier = AuthorityKeyIdentifier(pub_sha1);
+    let auth_key_identifier = vec![auth_key_identifier];
+    auth_key_identifier
+        .to_vec()
+        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))
+}
+
+fn gen_subject_alt_name() -> Result<alloc::vec::Vec<u8>, ResolveError> {
+    let mut tcg_tpm_manufaturer = SetOfVec::new();
+    let _ = tcg_tpm_manufaturer.add(DistinguishedName {
+        attribute_type: TCG_TPM_MANUFACTURER,
+        value: Utf8String::new("Intel").unwrap().into(),
+    });
+
+    let mut tcg_tpm_model = SetOfVec::new();
+    let _ = tcg_tpm_model.add(DistinguishedName {
+        attribute_type: TCG_TPM_MODEL,
+        value: Utf8String::new("vTPM").unwrap().into(),
+    });
+
+    let mut tcg_tpm_version = SetOfVec::new();
+    let _ = tcg_tpm_version.add(DistinguishedName {
+        attribute_type: TCG_TPM_VERSION,
+        value: Utf8String::new("00010000").unwrap().into(),
+    });
+
+    let sub_alt_name = vec![tcg_tpm_manufaturer, tcg_tpm_model, tcg_tpm_version];
+    let sub_alt_name: SubjectAltName = SubjectAltName(sub_alt_name);
+    let sub_alt_name = vec![sub_alt_name];
+    sub_alt_name
         .to_vec()
         .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))
 }
@@ -115,45 +159,33 @@ pub fn generate_ek_cert(
         parameters: None,
     };
 
+    // basic constrains
     let basic_constrains: alloc::vec::Vec<bool> = vec![false];
     let basic_constrains = basic_constrains
         .to_vec()
         .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
 
-    let ek_pub_sha1 = digest::digest(&digest::SHA1_FOR_LEGACY_USE_ONLY, ek_pub);
-    let key_identifier: alloc::vec::Vec<u8> = ek_pub_sha1.as_ref().to_vec();
+    // extended key usage
+    let eku: alloc::vec::Vec<ObjectIdentifier> = vec![TCG_EK_CERTIFICATE];
+    let eku = eku
+        .to_vec()
+        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
+
+    // authority key identifier
+    let auth_key_identifier = gen_auth_key_identifier(ek_pub)?;
 
     // follow ek-credential spec Section 3.2.
     // keyAgreement (4) refers to https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.3
-    let ku: alloc::vec::Vec<u8> = vec![4_u8];
-    let ku: alloc::vec::Vec<u8> = ku
+    let ku = BitString::new(0, &[0x08])
+        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
+    let ku = ku
         .to_vec()
         .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
 
-    let mut tcg_tpm_manufaturer = SetOfVec::new();
-    let _ = tcg_tpm_manufaturer.add(DistinguishedName {
-        attribute_type: TCG_TPM_MANUFACTURER,
-        value: PrintableString::new("Intel").unwrap().into(),
-    });
+    // subject alt name
+    let subject_alt_name = gen_subject_alt_name()?;
 
-    let mut tcg_tpm_model = SetOfVec::new();
-    let _ = tcg_tpm_model.add(DistinguishedName {
-        attribute_type: TCG_TPM_MODEL,
-        value: PrintableString::new("vTPM").unwrap().into(),
-    });
-
-    let mut tcg_tpm_version = SetOfVec::new();
-    let _ = tcg_tpm_version.add(DistinguishedName {
-        attribute_type: TCG_TPM_VERSION,
-        value: PrintableString::new("00010000").unwrap().into(),
-    });
-
-    let sub_alt_name = vec![tcg_tpm_manufaturer, tcg_tpm_model, tcg_tpm_version];
-    let sub_alt_name: alloc::vec::Vec<u8> = sub_alt_name
-        .to_vec()
-        .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
-
-    let x509_certificate = x509::CertificateBuilder::new(sig_alg, algorithm, ek_pub)?
+    let x509_certificate = x509::CertificateBuilder::new(sig_alg, algorithm, ek_pub, false)?
         // 1970-01-01T00:00:00Z
         .set_not_before(core::time::Duration::new(0, 0))?
         // 9999-12-31T23:59:59Z
@@ -166,13 +198,18 @@ pub fn generate_ek_cert(
         .add_extension(Extension::new(
             AUTHORITY_KEY_IDENTIFIER,
             Some(false),
-            Some(&key_identifier.as_slice()),
+            Some(auth_key_identifier.as_slice()),
         )?)?
-        .add_extension(Extension::new(KEY_USAGE, Some(true), Some(&ku))?)?
+        .add_extension(Extension::new(KEY_USAGE, Some(true), Some(ku.as_slice()))?)?
+        .add_extension(Extension::new(
+            EXTENDED_KEY_USAGE,
+            Some(false),
+            Some(eku.as_slice()),
+        )?)?
         .add_extension(Extension::new(
             SUBJECT_ALT_NAME,
-            Some(false),
-            Some(&sub_alt_name),
+            Some(true),
+            Some(subject_alt_name.as_slice()),
         )?)?
         .sign(&mut sig_buf, signer)?
         .build();

--- a/src/crypto/src/resolve.rs
+++ b/src/crypto/src/resolve.rs
@@ -44,6 +44,8 @@ pub const EXTNID_TDVF_QUOTE: ObjectIdentifier =
 pub const SERVER_AUTH: ObjectIdentifier = ObjectIdentifier::new("1.3.6.1.5.5.7.3.1");
 pub const CLIENT_AUTH: ObjectIdentifier = ObjectIdentifier::new("1.3.6.1.5.5.7.3.2");
 
+pub const TCG_EK_CERTIFICATE: ObjectIdentifier = ObjectIdentifier::new("2.23.133.8.1");
+
 // As specified in https://datatracker.ietf.org/doc/html/rfc5480#appendix-A
 // id-ecPublicKey OBJECT IDENTIFIER ::= {
 //     iso(1) member-body(2) us(840) ansi-X9-62(10045) keyType(2) 1
@@ -126,7 +128,7 @@ pub fn generate_certificate(
         .to_vec()
         .map_err(|e| ResolveError::GenerateCertificate(X509Error::DerEncoding(e)))?;
     let x509_certificate =
-        x509::CertificateBuilder::new(sig_alg, algorithm, key_pair.public_key().as_ref())?
+        x509::CertificateBuilder::new(sig_alg, algorithm, key_pair.public_key().as_ref(), true)?
             // 1970-01-01T00:00:00Z
             .set_not_before(core::time::Duration::new(0, 0))?
             // 9999-12-31T23:59:59Z


### PR DESCRIPTION
Fix #116 

This patch fixed below errors in ek-cert:
1. ek-cert is not self-signed, so the issuer and subject shall not be the same value.
2. Fix the authority-key-identifier error
3. Fix the subject-alt-name error
4. Fix the key-usage error