### PR TITLE
use docker for reproducible build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:22.04
+
+# Adding rust binaries to PATH.
+ENV PATH="$PATH:/root/.cargo/bin"
+WORKDIR /root
+
+# Install all required packages in one go to optimize the image
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
+# DEBIAN_FRONTEND is set for tzdata.
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    build-essential unzip ca-certificates curl gcc git libssl-dev pkg-config ssh \
+    clang llvm nasm \
+    ocaml ocamlbuild wget pkg-config libtool autoconf autotools-dev automake \
+    screen expect \
+    # cleanup
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install rustup and a fixed version of Rust.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-08-28
+RUN rustup component add rust-src
+RUN cargo install cargo-xbuild
+
+RUN git clone --recursive https://github.com/intel/vtpm-td.git

--- a/README.md
+++ b/README.md
@@ -169,3 +169,16 @@ After booting up to TD guest OS, vTPM features can be used as normal TPM. It can
 * [tpm2-tools](doc/verify-vtpm-features.md#tpm2-tools)
 * [Linux IMA (Integrity Measurement Architecture)](doc/verify-vtpm-features.md#linux-ima)
 * [Keylime](doc/verify-vtpm-features.md#keylime)
+
+## Reproducible Build
+
+Reproducible build of vtpm-td binary requires same system user and
+source code path (see https://github.com/intel/vtpm-td/issues/101).
+
+The [Dockerfile](./Dockerfile) is provided to build the docker image with
+the vtpm-td compilation environment for reproducible build. You can use the
+[docker.sh](./sh_script/docker.sh) to build and run the docker container:
+
+```
+./sh_script/docker.sh -f ./
+```

--- a/sh_script/docker.sh
+++ b/sh_script/docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+FOLDER=""
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -d <docker file>     Path of Dockerfile.
+EOM
+}
+
+error() {
+    echo -e "\e[1;31mERROR: $*\e[0;0m"
+    exit 1
+}
+
+process_args() {
+    while getopts ":f:h" option; do
+        case "$option" in
+            f) FOLDER=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    if [[ -z ${FOLDER} ]]; then
+        error "Please specify the folder of where the Dockerfile is located through -f."
+    fi
+
+    if [[ ! -f "${FOLDER}/Dockerfile" ]]; then
+        error "Dockerfile does not exist."
+    fi
+}
+
+process_args $@
+
+pushd ${FOLDER}
+
+# If the docker image does not exist, build the docker image
+set +e && docker image inspect vtpmtd.build.env:latest > /dev/null 2>&1 && set -e
+if [ $? != 0 ]; then
+    docker build -t vtpmtd.build.env \
+            --build-arg https_proxy=$https_proxy \
+            --build-arg http_proxy=$http_proxy \
+            .
+fi
+
+popd
+
+# Run the docker image
+docker run -it --rm vtpmtd.build.env


### PR DESCRIPTION
The reproducible build of vtpm-td binary requires same user and code path, `Dockerfile` is provided for reproducibility.

Fix: https://github.com/intel/vtpm-td/issues/101