### PR TITLE
Set postBuffer to fix CI RPC fail

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -22,6 +22,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+    - run: git config --global http.postBuffer 524288000
+    - run: git config --global   http.sslVerify "false"
     - run: git submodule update --init --recursive
     - run: bash sh_script/pre-build.sh
     - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize and update submodules
-        run: git submodule update --init --recursive
+        run: |
+          git config --global http.postBuffer 524288000
+          git config --global   http.sslVerify "false"
+          git submodule update --init --recursive
 
       # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
@@ -67,7 +70,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize and update submodules
-        run: git submodule update --init --recursive
+        run: |
+          git config --global http.postBuffer 524288000
+          git config --global   http.sslVerify "false"
+          git submodule update --init --recursive
 
       - name: Install toolchain with rustfmt available
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,7 +22,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize and update submodules
-        run: git submodule update --init --recursive
+        run: |
+          git config --global http.postBuffer 524288000
+          git config --global   http.sslVerify "false"
+          git submodule update --init --recursive
       
       - name: Checkout sources - TDVF
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,10 @@ jobs:
           uses: actions/checkout@v4
 
         - name: Initialize and update submodules
-          run: git submodule update --init --recursive
+          run: |
+            git config --global http.postBuffer 524288000
+            git config --global http.sslVerify "false"
+            git submodule update --init --recursive
         
         - name: Install LLVM and Clang
           uses: KyleMayes/install-llvm-action@v1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,7 +27,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize and update submodules
-        run: git submodule update --init --recursive
+        run: |
+          git config --global http.postBuffer 524288000
+          git config --global   http.sslVerify "false"
+          git submodule update --init --recursive
 
       # Install first since it's needed to build NASM
       - name: Install LLVM and Clang


### PR DESCRIPTION
Fix: #163 
During Cloning into '/home/runner/work/vtpm-td/vtpm-td/deps/rust-tpm-20-ref/smallc/musl'..., CI will meet below error:
`error: RPC failed; HTTP 504 curl 22 The requested URL returned error: 504`

The default postBuffer is 1M, it's not enough for git cloning musl submodule. So the env should set postBuffer and disable http.sslVerify to avoid RPC fail.