### PR TITLE
Add '--depth 1' parament for fix cloning musl randomly fail

### DIFF
--- a/.github/workflows/deny.yml
+++ b/.github/workflows/deny.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v4
     - run: git config --global http.postBuffer 524288000
     - run: git config --global   http.sslVerify "false"
-    - run: git submodule update --init --recursive
+    - run: git submodule update --init --recursive --depth 1
     - run: bash sh_script/pre-build.sh
     - uses: EmbarkStudios/cargo-deny-action@v1
       with:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config --global http.postBuffer 524288000
           git config --global   http.sslVerify "false"
-          git submodule update --init --recursive
+          git submodule update --init --recursive --depth 1
 
       # Install first since it's needed to build NASM
       - name: Install LLVM and Clang
@@ -73,7 +73,7 @@ jobs:
         run: |
           git config --global http.postBuffer 524288000
           git config --global   http.sslVerify "false"
-          git submodule update --init --recursive
+          git submodule update --init --recursive --depth 1
 
       - name: Install toolchain with rustfmt available
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           git config --global http.postBuffer 524288000
           git config --global   http.sslVerify "false"
-          git submodule update --init --recursive
+          git submodule update --init --recursive --depth 1
       
       - name: Checkout sources - TDVF
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           run: |
             git config --global http.postBuffer 524288000
             git config --global http.sslVerify "false"
-            git submodule update --init --recursive
+            git submodule update --init --recursive --depth 1
         
         - name: Install LLVM and Clang
           uses: KyleMayes/install-llvm-action@v1

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           git config --global http.postBuffer 524288000
           git config --global   http.sslVerify "false"
-          git submodule update --init --recursive
+          git submodule update --init --recursive --depth 1
 
       # Install first since it's needed to build NASM
       - name: Install LLVM and Clang


### PR DESCRIPTION
Fix: #166
Fix cloning musl randomly fail.

Add parament for accelerating git clone speed and CI build speed to avoid clone fail.
`git submodule update --init --recursive --depth 1`

`--depth 1` means create a shallow clone with a history truncated to the specified number of commits, here is 1.