### PR TITLE
Remove MigTd prefix in AttestLibError to avoid confusing

### DIFF
--- a/src/attestation/src/attest.rs
+++ b/src/attestation/src/attest.rs
@@ -36,7 +36,7 @@ pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
             quote.as_mut_ptr() as *mut c_void,
             &mut quote_size as *mut u32,
         );
-        if result != AttestLibError::MigtdAttestSuccess {
+        if result != AttestLibError::AttestSuccess {
             return Err(Error::GetQuote);
         }
     }
@@ -68,7 +68,7 @@ pub fn verify_quote(quote: &[u8]) -> Result<Vec<u8>, Error> {
             td_report_verify.as_mut_ptr() as *mut c_void,
             &mut report_verify_size as *mut u32,
         );
-        if result != AttestLibError::MigtdAttestSuccess {
+        if result != AttestLibError::AttestSuccess {
             return Err(Error::VerifyQuote);
         }
     }

--- a/src/attestation/src/binding.rs
+++ b/src/attestation/src/binding.rs
@@ -7,29 +7,29 @@
 #[derive(Debug, PartialEq)]
 pub(crate) enum AttestLibError {
     /// Success
-    MigtdAttestSuccess = 0x0000,
+    AttestSuccess = 0x0000,
     /// Unexpected error
-    MigtdAttestErrorUnexpected = 0x0001,
+    AttestErrorUnexpected = 0x0001,
     /// The parameter is incorrect
-    MigtdAttestErrorInvalidParameter = 0x0002,
+    AttestErrorInvalidParameter = 0x0002,
     /// Not enough memory is available to complete this operation
-    MigtdAttestErrorOutOfMemory = 0x0003,
+    AttestErrorOutOfMemory = 0x0003,
     /// vsock related failure
-    MigtdAttestErrorVsockFailure = 0x0004,
+    AttestErrorVsockFailure = 0x0004,
     /// Failed to get the TD Report
-    MigtdAttestErrorReportFailure = 0x0005,
+    AttestErrorReportFailure = 0x0005,
     /// Failed to extend rtmr
-    MigtdAttestErrorExtendFailure = 0x0006,
+    AttestErrorExtendFailure = 0x0006,
     /// Request feature is not supported
-    MigtdAttestErrorNotSupported = 0x0007,
+    AttestErrorNotSupported = 0x0007,
     /// Failed to get the TD Quote
-    MigtdAttestErrorQuoteFailure = 0x0008,
+    AttestErrorQuoteFailure = 0x0008,
     /// The device driver return busy
-    MigtdAttestErrorBusy = 0x0009,
+    AttestErrorBusy = 0x0009,
     /// Failed to acess tdx attest device
-    MigtdAttestErrorDeviceFailure = 0x000a,
+    AttestErrorDeviceFailure = 0x000a,
     /// Only supported RTMR index is 2 and 3
-    MigtdAttestErrorInvalidRtmrIndex = 0x000b,
+    AttestErrorInvalidRtmrIndex = 0x000b,
 }
 
 extern "C" {

--- a/src/attestation/src/ghci.rs
+++ b/src/attestation/src/ghci.rs
@@ -21,7 +21,7 @@ pub static NOTIFIER: AtomicU8 = AtomicU8::new(0);
 #[no_mangle]
 pub extern "C" fn migtd_get_quote(tdquote_req_buf: *mut c_void, len: u64) -> i32 {
     if tdquote_req_buf == null_mut() || len > GET_QUOTE_MAX_SIZE {
-        return AttestLibError::MigtdAttestErrorInvalidParameter as i32;
+        return AttestLibError::AttestErrorInvalidParameter as i32;
     }
 
     let input = unsafe { from_raw_parts_mut(tdquote_req_buf as *mut u8, len as usize) };
@@ -29,14 +29,14 @@ pub extern "C" fn migtd_get_quote(tdquote_req_buf: *mut c_void, len: u64) -> i32
     let mut shared = if let Some(shared) = SharedMemory::new(len as usize / 0x1000) {
         shared
     } else {
-        return AttestLibError::MigtdAttestErrorOutOfMemory as i32;
+        return AttestLibError::AttestErrorOutOfMemory as i32;
     };
     shared.as_mut_bytes()[..len as usize].copy_from_slice(input);
 
     set_vmm_notification();
 
     if tdvmcall_get_quote(shared.as_mut_bytes()).is_err() {
-        return AttestLibError::MigtdAttestErrorQuoteFailure as i32;
+        return AttestLibError::AttestErrorQuoteFailure as i32;
     }
 
     wait_for_vmm_notification();


### PR DESCRIPTION
Fix: #75 

Only do the renaming work