### PR TITLE
Fix oss-fuzz failure issue

### DIFF
--- a/src/crypto/fuzz/Cargo.toml
+++ b/src/crypto/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ afl = {version = "*", optional = true }
 log = "0.4.13"
 arbitrary = "=1.1.3"
 der = {version = "0.5.1", features = ["oid", "alloc", "derive"]}
+serde = "=1.0.198"
 
 [dependencies.crypto]
 path = ".."


### PR DESCRIPTION
Refer to https://github.com/intel/vtpm-td/actions/runs/9886146891/job/27305372999.
Since the compiler of oss-fuzz is not the latest version, so it will meet build failure for crate "serde 1.0.204". So we use a fixed version serde 1.0.198  to fix the issue.